### PR TITLE
Getting rid of all the rspec deprecation warnings.

### DIFF
--- a/spec/shoes/configuration_spec.rb
+++ b/spec/shoes/configuration_spec.rb
@@ -50,7 +50,7 @@ describe Furoshiki::Shoes::Configuration do
 
   context "with options" do
     include_context 'config'
-    subject { Furoshiki::Shoes::Configuration.load(config_filename) }
+    subject { Furoshiki::Shoes::Configuration.load(@config_filename) }
 
     its(:name) { should eq('Sugar Clouds') }
     its(:shortname) { should eq('sweet-nebulae') }
@@ -62,7 +62,7 @@ describe Furoshiki::Shoes::Configuration do
     its(:release) { should eq('Mindfully') }
     its(:icons) { should be_an_instance_of(Hash) }
     its(:dmg) { should be_an_instance_of(Hash) }
-    its(:working_dir) { should eq(config_filename.dirname) }
+    its(:working_dir) { should eq(@config_filename.dirname) }
     it { should be_valid }
 
     describe "#icons" do
@@ -115,7 +115,7 @@ describe Furoshiki::Shoes::Configuration do
 
   context "when osx icon is not specified" do
     include_context 'config'
-    let(:valid_config) { Furoshiki::Shoes::Configuration.load(config_filename) }
+    let(:valid_config) { Furoshiki::Shoes::Configuration.load(@config_filename) }
     let(:options) { valid_config.to_hash.merge(:icons => {}) }
     subject { Furoshiki::Shoes::Configuration.new(options) }
 
@@ -144,7 +144,7 @@ describe Furoshiki::Shoes::Configuration do
 
     context "without a path" do
       it "looks for 'app.yaml' in current directory" do
-        Dir.chdir config_filename.parent do
+        Dir.chdir @config_filename.parent do
           config = Furoshiki::Shoes::Configuration.load
           config.shortname.should eq('sweet-nebulae')
         end
@@ -167,22 +167,22 @@ describe Furoshiki::Shoes::Configuration do
     end
 
     context "with an 'app.yaml'" do
-      let(:path) { config_filename }
+      let(:path) { @config_filename }
       it_behaves_like "config with path"
     end
 
     context "with a path to a directory containing an 'app.yaml'" do
-      let(:path) { config_filename.parent }
+      let(:path) { @config_filename.parent }
       it_behaves_like "config with path"
     end
 
     context "with a path to a file that is siblings with an 'app.yaml'" do
-      let(:path) { config_filename.parent.join('sibling.rb') }
+      let(:path) { @config_filename.parent.join('sibling.rb') }
       it_behaves_like "config with path"
     end
 
     context "with a path that exists, but no 'app.yaml'" do
-      let(:path) { config_filename.parent.join('bin/hello_world') }
+      let(:path) { @config_filename.parent.join('bin/hello_world') }
       subject { Furoshiki::Shoes::Configuration.load(path) }
 
       its(:name) { should eq('hello_world') }

--- a/spec/shoes/support/shared_config.rb
+++ b/spec/shoes/support/shared_config.rb
@@ -2,5 +2,7 @@ require 'yaml'
 require 'pathname'
 
 shared_context 'config' do
-  let(:config_filename) { Pathname.new(__FILE__).join('../../test_app/app.yaml').cleanpath }
+  before :all do
+    @config_filename = Pathname.new(__FILE__).join('../../test_app/app.yaml').cleanpath
+  end
 end

--- a/spec/shoes/swt_jar_spec.rb
+++ b/spec/shoes/swt_jar_spec.rb
@@ -11,17 +11,18 @@ describe Furoshiki::Shoes::SwtJar do
 
   context "when creating a .jar" do
     before :all do
-      output_dir.rmtree if output_dir.exist?
-      output_dir.mkpath
-      Dir.chdir app_dir do
-        @jar_path = subject.package(output_dir)
+      @output_dir.rmtree if @output_dir.exist?
+      @output_dir.mkpath
+      config = Furoshiki::Shoes::Configuration.load(@config_filename)
+      @subject = Furoshiki::Shoes::SwtJar.new(config)
+      Dir.chdir @app_dir do
+        @jar_path = @subject.package(@output_dir)
       end
     end
 
     let(:jar_name) { 'sweet-nebulae.jar' }
-    let(:output_file) { Pathname.new(output_dir.join jar_name) }
-    let(:config) { Furoshiki::Shoes::Configuration.load(config_filename) }
-    subject { Furoshiki::Shoes::SwtJar.new(config) }
+    let(:output_file) { Pathname.new(@output_dir.join jar_name) }
+    subject { @subject }
 
     it "creates a .jar" do
       output_file.should exist
@@ -40,7 +41,7 @@ describe Furoshiki::Shoes::SwtJar do
       jar.entries.should_not include("dir_to_ignore/file_to_ignore")
     end
 
-    its(:default_dir) { should eq(output_dir) }
+    its(:default_dir) { should eq(@output_dir) }
     its(:filename) { should eq(jar_name) }
   end
 

--- a/spec/support/shared_zip.rb
+++ b/spec/support/shared_zip.rb
@@ -1,21 +1,23 @@
 include ZipHelpers
 
 shared_context 'package' do
-  let(:app_dir) { spec_dir.join 'shoes/test_app' }
-  let(:output_dir) { app_dir.join 'pkg' }
+  before :all do
+    @app_dir = spec_dir.join 'shoes/test_app'
+    @output_dir = @app_dir.join 'pkg'
+  end
 end
 
 shared_context 'zip' do
   include_context 'package'
-  let(:output_file) { output_dir.join 'zip_directory_spec.zip' }
+  let(:output_file) { @output_dir.join 'zip_directory_spec.zip' }
   let(:zip) { Zip::ZipFile.open output_file }
 
   before :all do
-    output_dir.mkpath
-    subject.write
+    @output_dir.mkpath
+    @output_file = @output_dir.join 'zip_directory_spec.zip'
   end
 
   after :all do
-    FileUtils.rm_rf output_dir
+    FileUtils.rm_rf @output_dir
   end
 end

--- a/spec/zip/directory_contents_spec.rb
+++ b/spec/zip/directory_contents_spec.rb
@@ -3,22 +3,27 @@ require 'fileutils'
 require 'furoshiki/zip'
 
 describe Furoshiki::Zip::DirectoryContents do
-  subject { Furoshiki::Zip::DirectoryContents.new input_dir, output_file }
 
   context "output file" do
     include_context 'zip'
 
+    before :all do
+      zip_directory_contents = Furoshiki::Zip::DirectoryContents.new input_dir, @output_file
+      zip_directory_contents.write
+      @zip = Zip::ZipFile.open @output_file
+    end
+
     it "exists" do
-      output_file.should exist
+      @output_file.should exist
     end
 
     it "does not include input directory without parents" do
-      zip.entries.map(&:name).should_not include(add_trailing_slash input_dir.basename)
+      @zip.entries.map(&:name).should_not include(add_trailing_slash input_dir.basename)
     end
 
     relative_input_paths(input_dir).each do |path|
       it "includes all children of input directory" do
-        zip.entries.map(&:name).should include(path)
+        @zip.entries.map(&:name).should include(path)
       end
     end
   end

--- a/spec/zip/directory_spec.rb
+++ b/spec/zip/directory_spec.rb
@@ -8,23 +8,29 @@ describe Furoshiki::Zip::Directory do
   context "output file" do
     include_context 'zip'
 
+    before :all do
+      zip_directory = Furoshiki::Zip::Directory.new input_dir, @output_file
+      zip_directory.write
+      @zip = Zip::ZipFile.open @output_file
+    end
+
     it "exists" do
-      output_file.should exist
+      @output_file.should exist
     end
 
     it "includes input directory without parents" do
-      zip.entries.map(&:name).should include(add_trailing_slash input_dir.basename)
+      @zip.entries.map(&:name).should include(add_trailing_slash input_dir.basename)
     end
 
     relative_input_paths(input_dir.parent).each do |path|
       it "includes all children of input directory" do
-        zip.entries.map(&:name).should include(path)
+        @zip.entries.map(&:name).should include(path)
       end
     end
 
     it "doesn't include extra files" do
       number_of_files = Dir.glob("#{input_dir}/**/*").push(input_dir).length
-      zip.entries.length.should eq(number_of_files)
+      @zip.entries.length.should eq(number_of_files)
     end
   end
 end


### PR DESCRIPTION
- the warnings were concerning usage of let/subject in before :all
- approach is to substitute them with instance variables/local
  vars
- not perfect but working for now, feel free to give feedback =)
- fixes #2

Oh yeah and there were like a ton of those warnings.
