### PR TITLE
Bump to version 0.3.0

### DIFF
--- a/lib/furoshiki/version.rb
+++ b/lib/furoshiki/version.rb
@@ -1,4 +1,4 @@
 module Furoshiki
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end
 


### PR DESCRIPTION
This will coordinate with the 4.0.0.pre3 release of Shoes.

See shoes/shoes4#1008

This should be mergable now, and we'll cut the new gem version as we're
releasing the new shoes (to minimize time when folks with `>= 0.1.2` version
contraints in earlier shoes would get the wrong thing, without a newer shoes
available to install instead.)