### PR TITLE
Update to Furoshiki template

### DIFF
--- a/lib/furoshiki/configuration.rb
+++ b/lib/furoshiki/configuration.rb
@@ -15,7 +15,7 @@ module Furoshiki
   # after initialization, dump it with #to_hash, make your changes,
   # and instantiate a new object.
   class Configuration
-    JAR_APP_TEMPLATE_URL = 'https://s3.amazonaws.com/net.wasnotrice.shoes/wrappers/shoes-app-template-0.0.1.zip'
+    JAR_APP_TEMPLATE_URL = 'https://s3.amazonaws.com/net.wasnotrice.shoes/wrappers/shoes-app-template-0.0.2.zip'
 
     include Util
 

--- a/lib/furoshiki/jar_app.rb
+++ b/lib/furoshiki/jar_app.rb
@@ -90,7 +90,7 @@ module Furoshiki
     end
 
     def latest_template_version
-      '0.0.1'
+      '0.0.2'
     end
 
     def download_template
@@ -158,7 +158,7 @@ module Furoshiki
     # @param [Pathname, String] jar_path the location of the JAR to inject
     def inject_jar(jar_path)
       jar_dir = tmp_app_path.join('Contents/Java')
-      jar_dir.rmtree
+      jar_dir.rmtree if File.exist?(jar_dir)
       jar_dir.mkdir
       cp Pathname.new(jar_path), jar_dir
     end


### PR DESCRIPTION
After the issues being had in [#16](https://github.com/shoes/furoshiki/issues/16), as well as the issue I was having over in [#1071](https://github.com/shoes/shoes4/issues/1071), I looked at updating the shoes app template for packaging for Mac. Since it seemed that the JDK used in the template was causing the problem that @justahero and I were running into, I updated to the newest JDK, 1.8.0u40, and used @justahero 's instructions in [#16](https://github.com/shoes/furoshiki/issues/16) to fix it. I also was able to pare down the template to just use the JRE instead of the whole JDK, as justified by [this article](http://docs.oracle.com/javase/7/docs/technotes/guides/jweb/packagingAppsForMac.html#bundle_jre) which uses the [AppBundler](https://java.net/downloads/appbundler/appbundler.html). If you look, it says 

> By default, only the contents of the jre/ directory will be included with the bundled application. All executable content (i.e. bin/, jre/bin/) is excluded. Additional content can be included or excluded using nested <include> and <exclude> elements, respectively.

So I have a new template uploaded to my dropbox at [https://www.dropbox.com/s/dy4egm5itccfubm/shoes-app-template-0.0.2.zip?dl=0](https://www.dropbox.com/s/dy4egm5itccfubm/shoes-app-template-0.0.2.zip?dl=0), which has just the JRE portion of that JDK included. I tested packaging apps with it by unzipping it and placing that template into my cache directory, which since I wasn't using `ENV['FUROSHIKI_HOME']`, was `~/.furoshiki/cache/`. Then furoshiki thinks it doesn't need to download it. The packaged app worked on machines that did and did not have the JDK/JRE installed (and it worked every time).

I think to merge this in we should put the new template into @wasnotrice 's S3 bucket. Unfortunately, with the new JDK version, it seems to be a bit bigger than the old template, even though I pared it down to just the JRE. The zip is over 100 MB. :( I know package size is still a concern as referenced in [#9](https://github.com/shoes/furoshiki/issues/9), but I'm not sure what to do in this case as the previously bundled JDK was causing problems. 

Thanks @PragTob for pointing me in the right direction to work on this.