### PR TITLE
Move exclusion list construction after extensions

### DIFF
--- a/lib/furoshiki/configuration.rb
+++ b/lib/furoshiki/configuration.rb
@@ -79,10 +79,12 @@ module Furoshiki
             children = Dir.glob("#{path}/**/*") if File.directory?(path)
             [path, *children]
           end.flatten
-          config.excludes.add FileList.new(ignore.flatten).pathmap(config.pathmaps.application.first)
           config.gem_excludes += [/^samples/, /^examples/, /^test/, /^spec/]
 
           warbler_extensions.customize(config) if warbler_extensions.respond_to? :customize
+
+          # Important this is after extensions can alter pathmaps.application
+          config.excludes.add FileList.new(ignore.flatten).pathmap(config.pathmaps.application.first)
         end
       end
       warbler_config

--- a/lib/furoshiki/version.rb
+++ b/lib/furoshiki/version.rb
@@ -1,4 +1,4 @@
 module Furoshiki
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,11 +2,27 @@ require 'spec_helper'
 require 'furoshiki/configuration'
 
 describe Furoshiki::Configuration do
-  context "defaults" do
-    let(:config) { Furoshiki::Configuration.new }
+  subject(:config) { Furoshiki::Configuration.new(raw_config) }
 
-    it "is valid" do
-      expect(config).to be_valid
+  let(:raw_config) { { warbler_extensions: OtherCustomization,
+                       ignore: "pkg" } }
+
+  class OtherCustomization < Furoshiki::WarblerExtensions
+    def customize(config)
+      # Actual behavior with shoes-package overrides the application name, so
+      # for testing purposes reset it here too.
+      config.pathmaps.application = ["shoes-app/%p"]
     end
+  end
+
+  it "is valid by default" do
+    expect(config).to be_valid
+  end
+
+  it "uses correct application path for exclusions" do
+    raw_config[:warbler_extensions] = OtherCustomization
+    raw_config[:ignore] = "pkg"
+
+    expect(config.to_warbler_config.excludes).to include("shoes-app/pkg")
   end
 end


### PR DESCRIPTION
The warbler_extensions that we call alter the application setting which
is used as part of building the exclusion paths. A change to set the
exclusions before the extension had run ended up making the wrong ignore
paths.