### PR TITLE
Windows "app" support

### DIFF
--- a/lib/furoshiki/base_app.rb
+++ b/lib/furoshiki/base_app.rb
@@ -1,0 +1,201 @@
+require 'furoshiki/configuration'
+require 'furoshiki/exceptions'
+require 'furoshiki/zip/directory'
+require 'furoshiki/jar'
+require 'fileutils'
+require 'open-uri'
+require 'net/http'
+
+module Furoshiki
+  class BaseApp
+    include FileUtils
+
+    # @param [Furoshiki::Shoes::Configuration] config user configuration
+    def initialize(config)
+      @config = config
+
+      unless config.valid?
+        raise Furoshiki::ConfigurationError, "Invalid configuration.\n#{config.error_message_list}"
+      end
+
+      home = ENV['FUROSHIKI_HOME'] || Dir.home
+      @cache_dir = Pathname.new(home).join('.furoshiki', 'cache')
+      @default_package_dir = working_dir.join('pkg')
+      @package_dir = default_package_dir
+      @default_template_path = cache_dir.join(template_filename)
+      @template_path = default_template_path
+      @tmp = @package_dir.join('tmp')
+    end
+
+    def package
+      remove_tmp
+      create_tmp
+
+      cache_template
+      extract_template
+
+      inject_files
+      inject_jar
+      after_built
+
+      move_to_package_dir tmp_app_path
+      after_moved
+    ensure
+      remove_tmp
+    end
+
+    # @return [Pathname] default package directory: ./pkg
+    attr_reader :default_package_dir
+
+    # @return [Pathname] package directory
+    attr_accessor :package_dir
+
+    # @return [Pathname] default path to app template
+    attr_reader :default_template_path
+
+    # @return [Pathname] path to app template
+    attr_accessor :template_path
+
+    # @return [Pathname] cache directory
+    attr_reader :cache_dir
+
+    # @param [Furoshiki::Shoes::Configuration] config user configuration
+    attr_reader :config
+
+    # @return [Pathname] app building temp directory
+    attr_reader :tmp
+
+    private
+
+    # Locations and names
+    def app_name
+      raise NotImplementedError
+    end
+
+    def template_basename
+      raise NotImplementedError
+    end
+
+    def latest_template_version
+      raise NotImplementedError
+    end
+
+    def remote_template_url
+      raise NotImplementedError
+    end
+
+    def template_extension
+      '.zip'
+    end
+
+    def template_filename
+      "#{template_basename}-#{latest_template_version}#{template_extension}"
+    end
+
+    def tmp_app_path
+      tmp.join app_name
+    end
+
+    def app_path
+      package_dir.join app_name
+    end
+
+    def working_dir
+      config.working_dir
+    end
+
+    # Temp helpers
+    def create_tmp
+      tmp.mkpath
+    end
+
+    def remove_tmp
+      tmp.rmtree if tmp.exist?
+    end
+
+    # Downloading
+    def download_template
+      download remote_template_url, template_path
+    end
+
+    def download(remote_url, local_path)
+      download_following_redirects remote_url, local_path
+    end
+
+    def download_following_redirects(remote_url, local_path, redirect_limit = 5)
+      if redirect_limit == 0
+        raise Furoshiki::DownloadError,
+              "Too many redirects trying to reach #{remote_url}"
+      end
+
+      uri = URI(remote_url)
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri.request_uri)
+        http.request request do |response|
+          case response
+          when Net::HTTPSuccess then
+            warn "Downloading #{remote_url} to #{local_path}"
+            open(local_path, 'wb') do |file|
+              response.read_body do |chunk|
+                file.write chunk
+              end
+            end
+          when Net::HTTPRedirection then
+            location = response['location']
+            warn "Redirected to #{location}"
+            download_following_redirects(location, local_path, redirect_limit - 1)
+          else
+            raise Furoshiki::DownloadError, "Couldn't download app template at #{remote_url}. #{response.value}"
+          end
+        end
+      end
+    end
+
+    # Template helpers
+    def cache_template
+      cache_dir.mkpath unless cache_dir.exist?
+      download_template unless template_path.size?
+    end
+
+    def extract_template
+      raise IOError, "Couldn't find app template at #{template_path}." unless template_path.size?
+      extracted_app = nil
+
+      ::Zip::File.open(template_path) do |zip_file|
+        zip_file.each do |entry|
+          p = tmp.join(entry.name)
+          p.dirname.mkpath
+          entry.extract(p)
+        end
+      end
+    end
+
+    # Packaging helpers
+    def inject_files
+      # Hook for allowing different app types to put there files in
+    end
+
+    def inject_jar
+      raise NotImplementedError("Tell us where the jar is")
+    end
+
+    def after_built
+    end
+
+    def after_moved
+    end
+
+    def move_to_package_dir(path)
+      dest = package_dir.join(app_name)
+      dest.rmtree if dest.exist?
+      mv path.to_s, dest
+    end
+
+    def ensure_jar_exists
+      jar = Jar.new(@config)
+      path = tmp.join(jar.filename)
+      jar.package(tmp) unless File.exist?(path)
+      path
+    end
+  end
+end

--- a/lib/furoshiki/jar_app.rb
+++ b/lib/furoshiki/jar_app.rb
@@ -1,168 +1,39 @@
-require 'furoshiki/exceptions'
-require 'furoshiki/zip/directory'
-require 'furoshiki/jar'
-require 'fileutils'
+require 'furoshiki/base_app'
 require 'plist'
-require 'open-uri'
-require 'net/http'
 
 module Furoshiki
-  class JarApp
-    include FileUtils
-
-    # @param [Furoshiki::Shoes::Configuration] config user configuration
-    def initialize(config)
-      @config = config
-
-      unless config.valid?
-        raise Furoshiki::ConfigurationError, "Invalid configuration.\n#{config.error_message_list}"
-      end
-
-      home = ENV['FUROSHIKI_HOME'] || Dir.home
-      @cache_dir = Pathname.new(home).join('.furoshiki', 'cache')
-      @default_package_dir = working_dir.join('pkg')
-      @package_dir = default_package_dir
-      @default_template_path = cache_dir.join(template_filename)
-      @template_path = default_template_path
-      @tmp = @package_dir.join('tmp')
-    end
-
-    # @return [Pathname] default package directory: ./pkg
-    attr_reader :default_package_dir
-
-    # @return [Pathname] package directory
-    attr_accessor :package_dir
-
-    # @return [Pathname] default path to .app template
-    attr_reader :default_template_path
-
-    # @return [Pathname] path to .app template
-    attr_accessor :template_path
-
-    # @return [Pathname] cache directory
-    attr_reader :cache_dir
-
-    attr_reader :config
-
-    attr_reader :tmp
-
-    def package
-      remove_tmp
-      create_tmp
-      cache_template
-      extract_template
-      inject_icon
-      inject_config
-      jar_path = ensure_jar_exists
-      inject_jar jar_path
-      move_to_package_dir tmp_app_path
-      tweak_permissions
-    rescue => e
-      raise e
-    ensure
-      remove_tmp
-    end
-
+  class JarApp < BaseApp
     private
-    def create_tmp
-      tmp.mkpath
-    end
 
-    def remove_tmp
-      tmp.rmtree if tmp.exist?
-    end
-
-    def cache_template
-      cache_dir.mkpath unless cache_dir.exist?
-      download_template unless template_path.size?
+    def app_name
+      "#{config.name}.app"
     end
 
     def template_basename
       'shoes-app-template'
     end
 
-    def template_extension
-      '.zip'
-    end
-
-    def template_filename
-      "#{template_basename}-#{latest_template_version}#{template_extension}"
-    end
-
     def latest_template_version
       '0.0.2'
-    end
-
-    def download_template
-      download remote_template_url, template_path
-    end
-
-    def download(remote_url, local_path)
-      download_following_redirects remote_url, local_path
-    end
-
-    def download_following_redirects(remote_url, local_path, redirect_limit = 5)
-      if redirect_limit == 0
-        raise Furoshiki::DownloadError,
-              "Too many redirects trying to reach #{remote_url}"
-      end
-
-      uri = URI(remote_url)
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
-        request = Net::HTTP::Get.new(uri.request_uri)
-        http.request request do |response|
-          case response
-          when Net::HTTPSuccess then
-            warn "Downloading #{remote_url} to #{local_path}"
-            open(local_path, 'wb') do |file|
-              response.read_body do |chunk|
-                file.write chunk
-              end
-            end
-          when Net::HTTPRedirection then
-            location = response['location']
-            warn "Redirected to #{location}"
-            download_following_redirects(location, local_path, redirect_limit - 1)
-          else
-            raise Furoshiki::DownloadError, "Couldn't download app template at #{remote_url}. #{response.value}"
-          end
-        end
-      end
-    end
-
-    def downloads_url
-      "http://shoesrb.com/downloads"
     end
 
     def remote_template_url
       config.template_urls.fetch(:jar_app)
     end
 
-    def move_to_package_dir(path)
-      dest = package_dir.join(path.basename)
-      dest.rmtree if dest.exist?
-      mv path.to_s, dest
-    end
-
-    def ensure_jar_exists
-      jar = Jar.new(@config)
-      path = tmp.join(jar.filename)
-      jar.package(tmp) unless File.exist?(path)
-      path
-    end
-
     # Injects JAR into APP. The JAR should be the only item in the
     # Contents/Java directory. If this directory contains more than one
     # JAR, the "first" one gets run, which may not be what we want.
-    #
-    # @param [Pathname, String] jar_path the location of the JAR to inject
-    def inject_jar(jar_path)
+    def inject_jar
+      jar_path = ensure_jar_exists
+
       jar_dir = tmp_app_path.join('Contents/Java')
       jar_dir.rmtree if File.exist?(jar_dir)
       jar_dir.mkdir
       cp Pathname.new(jar_path), jar_dir
     end
 
+    # TODO: Extract to base after figuring the .app-finding move
     def extract_template
       raise IOError, "Couldn't find app template at #{template_path}." unless template_path.size?
       extracted_app = nil
@@ -176,6 +47,11 @@ module Furoshiki
         end
       end
       mv tmp.join(extracted_app.basename.to_s), tmp_app_path
+    end
+
+    def inject_files
+      inject_icon
+      inject_config
     end
 
     def inject_config
@@ -198,28 +74,12 @@ module Furoshiki
       end
     end
 
-    def tweak_permissions
+    def after_moved
       executable_path.chmod 0755
-    end
-
-    def app_name
-      "#{config.name}.app"
-    end
-
-    def tmp_app_path
-      tmp.join app_name
-    end
-
-    def app_path
-      package_dir.join app_name
     end
 
     def executable_path
       app_path.join('Contents/MacOS/JavaAppLauncher')
-    end
-
-    def working_dir
-      config.working_dir
     end
   end
 end

--- a/lib/furoshiki/windows_app.rb
+++ b/lib/furoshiki/windows_app.rb
@@ -1,8 +1,8 @@
+require 'furoshiki/configuration'
 require 'furoshiki/exceptions'
 require 'furoshiki/zip/directory'
 require 'furoshiki/jar'
 require 'fileutils'
-require 'plist'
 require 'open-uri'
 require 'net/http'
 

--- a/lib/furoshiki/windows_app.rb
+++ b/lib/furoshiki/windows_app.rb
@@ -1,0 +1,211 @@
+require 'furoshiki/exceptions'
+require 'furoshiki/zip/directory'
+require 'furoshiki/jar'
+require 'fileutils'
+require 'plist'
+require 'open-uri'
+require 'net/http'
+
+module Furoshiki
+  class WindowsApp
+    include FileUtils
+
+    # @param [Furoshiki::Shoes::Configuration] config user configuration
+    def initialize(config)
+      @config = config
+
+      unless config.valid?
+        raise Furoshiki::ConfigurationError, "Invalid configuration.\n#{config.error_message_list}"
+      end
+
+      home = ENV['FUROSHIKI_HOME'] || Dir.home
+      @cache_dir = Pathname.new(home).join('.furoshiki', 'cache')
+      @default_package_dir = working_dir.join('pkg')
+      @package_dir = default_package_dir
+      @default_template_path = cache_dir.join(template_filename)
+      @template_path = default_template_path
+      @tmp = @package_dir.join('tmp')
+    end
+
+    # @return [Pathname] default package directory: ./pkg
+    attr_reader :default_package_dir
+
+    # @return [Pathname] package directory
+    attr_accessor :package_dir
+
+    # @return [Pathname] default path to app template
+    attr_reader :default_template_path
+
+    # @return [Pathname] path to app template
+    attr_accessor :template_path
+
+    # @return [Pathname] cache directory
+    attr_reader :cache_dir
+
+    attr_reader :config
+
+    attr_reader :tmp
+
+    def package
+      remove_tmp
+      create_tmp
+      cache_template
+      extract_template
+      inject_icon
+      inject_config
+      jar_path = ensure_jar_exists
+      inject_jar jar_path
+      rename_application
+      move_to_package_dir tmp_app_path
+      tweak_permissions
+    ensure
+      remove_tmp
+    end
+
+    private
+
+    def create_tmp
+      tmp.mkpath
+    end
+
+    def remove_tmp
+      tmp.rmtree if tmp.exist?
+    end
+
+    def cache_template
+      cache_dir.mkpath unless cache_dir.exist?
+      download_template unless template_path.size?
+    end
+
+    def template_basename
+      'windows-app-template'
+    end
+
+    def template_extension
+      '.zip'
+    end
+
+    def template_filename
+      "#{template_basename}-#{latest_template_version}#{template_extension}"
+    end
+
+    def latest_template_version
+      '0.0.1'
+    end
+
+    def download_template
+      download remote_template_url, template_path
+    end
+
+    def download(remote_url, local_path)
+      download_following_redirects remote_url, local_path
+    end
+
+    def download_following_redirects(remote_url, local_path, redirect_limit = 5)
+      if redirect_limit == 0
+        raise Furoshiki::DownloadError,
+              "Too many redirects trying to reach #{remote_url}"
+      end
+
+      uri = URI(remote_url)
+      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri.request_uri)
+        http.request request do |response|
+          case response
+          when Net::HTTPSuccess then
+            warn "Downloading #{remote_url} to #{local_path}"
+            open(local_path, 'wb') do |file|
+              response.read_body do |chunk|
+                file.write chunk
+              end
+            end
+          when Net::HTTPRedirection then
+            location = response['location']
+            warn "Redirected to #{location}"
+            download_following_redirects(location, local_path, redirect_limit - 1)
+          else
+            raise Furoshiki::DownloadError, "Couldn't download app template at #{remote_url}. #{response.value}"
+          end
+        end
+      end
+    end
+
+    def remote_template_url
+      "https://github.com/jasonrclark/windows-app-templates/releases/download/v0.0.1/windows-app-template-0.0.1.zip"
+    end
+
+    def move_to_package_dir(path)
+      dest = package_dir.join(app_name)
+      dest.rmtree if dest.exist?
+      mv path.to_s, dest
+    end
+
+    def ensure_jar_exists
+      jar = Jar.new(@config)
+      path = tmp.join(jar.filename)
+      jar.package(tmp) unless File.exist?(path)
+      path
+    end
+
+    def inject_jar(jar_path)
+      cp Pathname.new(jar_path), File.join(tmp_app_path, "app.jar")
+    end
+
+    def extract_template
+      raise IOError, "Couldn't find app template at #{template_path}." unless template_path.size?
+      extracted_app = nil
+
+      ::Zip::File.open(template_path) do |zip_file|
+        zip_file.each do |entry|
+          p = tmp.join(entry.name)
+          p.dirname.mkpath
+          entry.extract(p)
+        end
+      end
+    end
+
+    def inject_config
+      #plist = tmp_app_path.join 'Contents/Info.plist'
+      #template = Plist.parse_xml(plist)
+      #template['CFBundleIdentifier'] = "com.hackety.shoes.#{config.shortname}"
+      #template['CFBundleDisplayName'] = config.name
+      #template['CFBundleName'] = config.name
+      #template['CFBundleVersion'] = config.version
+      #template['CFBundleIconFile'] = Pathname.new(config.icons[:osx]).basename.to_s if config.icons[:osx]
+      #File.open(plist, 'w') { |f| f.write template.to_plist }
+    end
+
+    def inject_icon
+      #if config.icons[:osx]
+        #icon_path = working_dir.join(config.icons[:osx])
+        #raise IOError, "Couldn't find app icon at #{icon_path}" unless icon_path.exist?
+        #resources_dir = tmp_app_path.join('Contents/Resources')
+        #cp icon_path, resources_dir.join(icon_path.basename)
+      #end
+    end
+
+    def rename_application
+      mv File.join(tmp_app_path, "app.bat"), File.join(tmp_app_path, "#{config.name}.bat")
+    end
+
+    def tweak_permissions
+      #executable_path.chmod 0755
+    end
+
+    def app_name
+      "#{config.name}-windows"
+    end
+
+    def tmp_app_path
+      tmp.join "#{template_basename}"
+    end
+
+    def app_path
+      package_dir.join app_name
+    end
+
+    def working_dir
+      config.working_dir
+    end
+  end
+end

--- a/lib/furoshiki/windows_app.rb
+++ b/lib/furoshiki/windows_app.rb
@@ -1,211 +1,36 @@
-require 'furoshiki/configuration'
-require 'furoshiki/exceptions'
-require 'furoshiki/zip/directory'
-require 'furoshiki/jar'
-require 'fileutils'
-require 'open-uri'
-require 'net/http'
+require 'furoshiki/base_app'
 
 module Furoshiki
-  class WindowsApp
-    include FileUtils
-
-    # @param [Furoshiki::Shoes::Configuration] config user configuration
-    def initialize(config)
-      @config = config
-
-      unless config.valid?
-        raise Furoshiki::ConfigurationError, "Invalid configuration.\n#{config.error_message_list}"
-      end
-
-      home = ENV['FUROSHIKI_HOME'] || Dir.home
-      @cache_dir = Pathname.new(home).join('.furoshiki', 'cache')
-      @default_package_dir = working_dir.join('pkg')
-      @package_dir = default_package_dir
-      @default_template_path = cache_dir.join(template_filename)
-      @template_path = default_template_path
-      @tmp = @package_dir.join('tmp')
-    end
-
-    # @return [Pathname] default package directory: ./pkg
-    attr_reader :default_package_dir
-
-    # @return [Pathname] package directory
-    attr_accessor :package_dir
-
-    # @return [Pathname] default path to app template
-    attr_reader :default_template_path
-
-    # @return [Pathname] path to app template
-    attr_accessor :template_path
-
-    # @return [Pathname] cache directory
-    attr_reader :cache_dir
-
-    attr_reader :config
-
-    attr_reader :tmp
-
-    def package
-      remove_tmp
-      create_tmp
-      cache_template
-      extract_template
-      inject_icon
-      inject_config
-      jar_path = ensure_jar_exists
-      inject_jar jar_path
-      rename_application
-      move_to_package_dir tmp_app_path
-      tweak_permissions
-    ensure
-      remove_tmp
-    end
-
+  class WindowsApp < BaseApp
     private
 
-    def create_tmp
-      tmp.mkpath
-    end
-
-    def remove_tmp
-      tmp.rmtree if tmp.exist?
-    end
-
-    def cache_template
-      cache_dir.mkpath unless cache_dir.exist?
-      download_template unless template_path.size?
+    def app_name
+      "#{config.name}-windows"
     end
 
     def template_basename
       'windows-app-template'
     end
 
-    def template_extension
-      '.zip'
-    end
-
-    def template_filename
-      "#{template_basename}-#{latest_template_version}#{template_extension}"
-    end
-
     def latest_template_version
       '0.0.1'
-    end
-
-    def download_template
-      download remote_template_url, template_path
-    end
-
-    def download(remote_url, local_path)
-      download_following_redirects remote_url, local_path
-    end
-
-    def download_following_redirects(remote_url, local_path, redirect_limit = 5)
-      if redirect_limit == 0
-        raise Furoshiki::DownloadError,
-              "Too many redirects trying to reach #{remote_url}"
-      end
-
-      uri = URI(remote_url)
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
-        request = Net::HTTP::Get.new(uri.request_uri)
-        http.request request do |response|
-          case response
-          when Net::HTTPSuccess then
-            warn "Downloading #{remote_url} to #{local_path}"
-            open(local_path, 'wb') do |file|
-              response.read_body do |chunk|
-                file.write chunk
-              end
-            end
-          when Net::HTTPRedirection then
-            location = response['location']
-            warn "Redirected to #{location}"
-            download_following_redirects(location, local_path, redirect_limit - 1)
-          else
-            raise Furoshiki::DownloadError, "Couldn't download app template at #{remote_url}. #{response.value}"
-          end
-        end
-      end
     end
 
     def remote_template_url
       "https://github.com/jasonrclark/windows-app-templates/releases/download/v0.0.1/windows-app-template-0.0.1.zip"
     end
 
-    def move_to_package_dir(path)
-      dest = package_dir.join(app_name)
-      dest.rmtree if dest.exist?
-      mv path.to_s, dest
-    end
-
-    def ensure_jar_exists
-      jar = Jar.new(@config)
-      path = tmp.join(jar.filename)
-      jar.package(tmp) unless File.exist?(path)
-      path
-    end
-
-    def inject_jar(jar_path)
+    def inject_jar
+      jar_path = ensure_jar_exists
       cp Pathname.new(jar_path), File.join(tmp_app_path, "app.jar")
     end
 
-    def extract_template
-      raise IOError, "Couldn't find app template at #{template_path}." unless template_path.size?
-      extracted_app = nil
-
-      ::Zip::File.open(template_path) do |zip_file|
-        zip_file.each do |entry|
-          p = tmp.join(entry.name)
-          p.dirname.mkpath
-          entry.extract(p)
-        end
-      end
-    end
-
-    def inject_config
-      #plist = tmp_app_path.join 'Contents/Info.plist'
-      #template = Plist.parse_xml(plist)
-      #template['CFBundleIdentifier'] = "com.hackety.shoes.#{config.shortname}"
-      #template['CFBundleDisplayName'] = config.name
-      #template['CFBundleName'] = config.name
-      #template['CFBundleVersion'] = config.version
-      #template['CFBundleIconFile'] = Pathname.new(config.icons[:osx]).basename.to_s if config.icons[:osx]
-      #File.open(plist, 'w') { |f| f.write template.to_plist }
-    end
-
-    def inject_icon
-      #if config.icons[:osx]
-        #icon_path = working_dir.join(config.icons[:osx])
-        #raise IOError, "Couldn't find app icon at #{icon_path}" unless icon_path.exist?
-        #resources_dir = tmp_app_path.join('Contents/Resources')
-        #cp icon_path, resources_dir.join(icon_path.basename)
-      #end
-    end
-
-    def rename_application
+    def after_built
       mv File.join(tmp_app_path, "app.bat"), File.join(tmp_app_path, "#{config.name}.bat")
-    end
-
-    def tweak_permissions
-      #executable_path.chmod 0755
-    end
-
-    def app_name
-      "#{config.name}-windows"
     end
 
     def tmp_app_path
       tmp.join "#{template_basename}"
-    end
-
-    def app_path
-      package_dir.join app_name
-    end
-
-    def working_dir
-      config.working_dir
     end
   end
 end

--- a/lib/furoshiki/windows_app.rb
+++ b/lib/furoshiki/windows_app.rb
@@ -17,7 +17,7 @@ module Furoshiki
     end
 
     def remote_template_url
-      "https://github.com/jasonrclark/windows-app-templates/releases/download/v0.0.1/windows-app-template-0.0.1.zip"
+      "https://github.com/shoes/windows-app-templates/releases/download/v#{latest_template_version}/windows-app-template-#{latest_template_version}.zip"
     end
 
     def inject_jar

--- a/spec/furoshiki/windows_app_spec.rb
+++ b/spec/furoshiki/windows_app_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+require 'pathname'
+require 'furoshiki/windows_app'
+
+include PackageHelpers
+
+describe Furoshiki::WindowsApp do
+  include_context 'generic furoshiki config'
+  include_context 'generic furoshiki project'
+
+  let(:config) { Furoshiki::Configuration.new @custom_config }
+  subject { Furoshiki::WindowsApp.new config }
+
+  let(:launcher) { @output_file.join('Ruby App.bat') }
+  let(:jar) { @output_file.join('app.jar') }
+
+  # $FUROSHIKI_HOME is set in spec_helper.rb for testing purposes,
+  # but should default to $HOME
+  describe "when not setting $FUROSHIKI_HOME" do
+    before do
+      @old_furoshiki_home = ENV['FUROSHIKI_HOME']
+      ENV['FUROSHIKI_HOME'] = nil
+    end
+
+    its(:cache_dir) { should eq(Pathname.new(Dir.home).join('.furoshiki', 'cache')) }
+
+    after do
+      ENV['FUROSHIKI_HOME'] = @old_furoshiki_home
+    end
+  end
+
+  describe "default" do
+    let(:cache_dir) { Pathname.new(FUROSHIKI_SPEC_DIR).join('.furoshiki', 'cache') }
+    its(:cache_dir) { should eq(cache_dir) }
+
+    it "sets package dir to {pwd}/pkg" do
+      Dir.chdir @app_dir do
+        expect(subject.default_package_dir).to eq(@app_dir.join 'pkg')
+      end
+    end
+
+    it "caches current version of template" do
+      expect(subject.template_path).to eq(cache_dir.join('windows-app-template-0.0.1.zip'))
+    end
+
+    its(:remote_template_url) { should match(%r{https://github.com/.*/windows-app-templates/releases/download/.*/windows-app-template.*.zip}) }
+  end
+
+  describe "when creating an app" do
+    before :all do
+      @output_dir.rmtree if @output_dir.exist?
+      @output_dir.mkpath
+
+      app_name = 'Ruby App-windows'
+      @output_file = @output_dir.join app_name
+
+      # Config picks up Dir.pwd
+      Dir.chdir @app_dir do
+        config = Furoshiki::Configuration.new(@custom_config)
+        @subject = Furoshiki::WindowsApp.new(config)
+        @subject.package
+      end
+    end
+
+    subject { @subject }
+
+    its(:template_path) { should exist }
+
+    it "creates the app directory" do
+      expect(@output_file).to exist
+    end
+
+    it "includes launcher" do
+      expect(launcher).to exist
+    end
+
+    it "injects jar" do
+      expect(jar).to exist
+    end
+  end
+
+  describe "with an invalid configuration" do
+    before do
+      allow(config).to receive(:valid?) { false }
+    end
+
+    it "fails to initialize" do
+      expect { subject }.to raise_error(Furoshiki::ConfigurationError)
+    end
+  end
+end


### PR DESCRIPTION
As discussed over in the [Shoes packaging plan](https://github.com/shoes/shoes4/issues/1415), our current aim is to get a "good enough" sort of distributable packaged up for all 3 OS's. This is the rough beginnings of support for Windows!

The moving pieces here are very similar to `Furoshiki::JarApp` with regards to building out a tmp dir based on a downloaded template zip file, then plugging the right pieces in. Plenty to be revised, consolidated, etc. here between the two flavors.

## Where's My Java?
There's one big difference between this and the Mac template, though, and that's the handling of the JRE.

The Mac template embeds a full JRE (roughly ~65MB) so that the thing can be guaranteed to run standalone without any intervention.

If you drag down the Windows template zip, it looks like this instead, clocking in at less than 2MB:

```
Archive:  /Users/jason/.furoshiki/cache/windows-app-template-0.0.1.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  04-02-17 21:41   windows-app-template/
      574  04-02-17 21:41   windows-app-template/app.bat
        0  04-02-17 21:17   windows-app-template/helpers/
    69120  04-02-17 21:17   windows-app-template/helpers/bzip2.dll
  1177600  04-02-17 21:17   windows-app-template/helpers/libeay32.dll
  1008128  04-02-17 21:17   windows-app-template/helpers/libiconv2.dll
   103424  04-02-17 21:17   windows-app-template/helpers/libintl3.dll
   232960  04-02-17 21:17   windows-app-template/helpers/libssl32.dll
   164864  04-02-17 21:17   windows-app-template/helpers/unzip.exe
   162816  04-02-17 21:17   windows-app-template/helpers/unzip32.dll
   449024  04-02-17 21:17   windows-app-template/helpers/wget.exe
```

What's up with that? Am I just assuming that the user will have a JRE available? Not at all!

[`app.bat`](https://github.com/jasonrclark/windows-app-templates/blob/master/base/app.bat) looks around to see if it can run `java`, and if it can't, it downloads a suitable JRE from our [Github releases](https://github.com/jasonrclark/windows-app-templates/releases). It tucks this JRE in a well-known spot (`~/.shoes/jdk`) so subsequent Shoes app runs can find and use it.

This approach allows folks that already have a JVM to just use it, while others will get something workable without having to make every package massive. Thoughts?

## Smaller Notes

* Startup is currently just a `.bat` but before 4.0 I want to replace that with a small native Windows binary that'll do a better job than Windows batch coding :shudders:
* Template zip is hosted as a Github release on https://github.com/jasonrclark/windows-app-templates. Currently still using the explicit version binding from `furoshiki` to the template it uses
* Simplified things in the template by assuming we'll copy the jar to `app.jar`. Now we only need to rename the start executable (currently `app.bat`) but the executable can look to a standard location for the actual jar to run.