### PR TITLE
Bump template version for mac to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+* New icon for Mac app template [#36]
+
 # 0.6.0
 
 * Output archives instead of loose files [#33]

--- a/lib/furoshiki/mac_app.rb
+++ b/lib/furoshiki/mac_app.rb
@@ -18,7 +18,7 @@ module Furoshiki
     end
 
     def latest_template_version
-      '0.0.3'
+      '0.0.4'
     end
 
     def remote_template_url

--- a/lib/furoshiki/version.rb
+++ b/lib/furoshiki/version.rb
@@ -1,4 +1,4 @@
 module Furoshiki
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end
 

--- a/spec/furoshiki/mac_app_spec.rb
+++ b/spec/furoshiki/mac_app_spec.rb
@@ -16,7 +16,7 @@ describe Furoshiki::MacApp do
 
   describe "default" do
     it "caches current version of template" do
-      expect(subject.template_path).to eq(cache_dir.join('mac-app-template-0.0.3.zip'))
+      expect(subject.template_path).to eq(cache_dir.join('mac-app-template-0.0.4.zip'))
     end
 
     its(:remote_template_url) { should match(%r{https://github.com/.*/mac-app-templates/releases/download/.*/mac-app-template.*.zip}) }


### PR DESCRIPTION
Need to update to use the new template... makes me wish we'd done #35 though.

Icon in action...
<img width="354" alt="mac-desktop" src="https://user-images.githubusercontent.com/130504/32408673-82f3bffc-c159-11e7-86d8-4a4c2c306c53.png">
